### PR TITLE
Fix bug with verilator's lint results not showing correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix bug with lint results not showing correctly for multi-level directories when using verilator as linter.
+
 ## [24.11.0] - 2024-11-05
 - Prevent file base names from being recognized as a hierarchical path.
 - Improved completions:
@@ -112,7 +115,7 @@
 - Improve Verilator package resolution
   - Verilator requires packages be specified beforehand, so this will iterate the verilator lint step, prepending packages that it complains about. More work should be done on this to produce a topo sort of the packages
 - use execFile for ctags (no shell)
-- Add index component 
+- Add index component
   - symlink index (.sv_cache/files)
   - in-memory file index, makes everything much much snappier
 

--- a/src/linter/VerilatorLinter.ts
+++ b/src/linter/VerilatorLinter.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode'
 import { ext } from '../extension'
 import { FileDiagnostic, isSystemVerilog } from '../utils'
 import BaseLinter from './BaseLinter'
+import * as path from 'path'
+import { getWorkspaceFolder } from '../utils'
 
 export default class VerilatorLinter extends BaseLinter {
   constructor(name: string) {
@@ -87,6 +89,13 @@ export default class VerilatorLinter extends BaseLinter {
       let elen = pline.length - pindex
       n += 2
       /// right index
+
+      //Convert to abs paths in case that verilator outputs relative paths
+      const workspacePath = getWorkspaceFolder()
+      if (workspacePath && !path.isAbsolute(file)) {
+          file = path.resolve(workspacePath, file)
+      }
+      file = path.normalize(file)
 
       if (!isNaN(lineNum)) {
         diagnostics.push({


### PR DESCRIPTION
Bug fix to issue [BUG] Linter Warnings/Errors Not Properly Marked in Multi-Level Directories #17
Added abs file path checking and converting codes in VerilatorLinter.ts