### PR TITLE
Add fading out unused variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Added fading unused variables reported by slang.
+
 ## [24.11.0] - 2024-11-05
 - Prevent file base names from being recognized as a hierarchical path.
 - Improved completions:

--- a/src/linter/SlangLinter.ts
+++ b/src/linter/SlangLinter.ts
@@ -74,16 +74,28 @@ export default class SlangLinter extends BaseLinter {
       }
       n += 2
 
+      let code = rex[7] ? rex[7] : 'error'
+
+      let tags = []
+
+      let severity = this.convertToSeverity(rex[4])
+
+      if (code.startsWith("unused")) {
+        tags.push(vscode.DiagnosticTag.Unnecessary)
+        severity = vscode.DiagnosticSeverity.Hint
+      }
+
       diags.push({
         file: filePath,
-        severity: this.convertToSeverity(rex[4]),
+        severity: severity,
         range: new vscode.Range(
           new vscode.Position(lineNum, begin),
           new vscode.Position(lineNum, end)
         ),
         message: msg,
-        code: rex[7] ? rex[7] : 'error',
+        code: code,
         source: 'slang',
+        tags: tags
       })
     }
 


### PR DESCRIPTION
Added "Unnecessary" diagnostic tag to fade out unused variables reported by slang.