### PR TITLE
Dev verible autoload

### DIFF
--- a/package.json
+++ b/package.json
@@ -708,6 +708,16 @@
             "type": "string"
           }
         },
+        "verilog.languageServer.pathToVeribleSyntax": {
+          "default": "verible-verilog-syntax",
+          "description": "Path to the verible-verilog-syntax tool",
+          "type": "string"
+        },
+        "verilog.languageServer.autoLoadModules": {
+          "default": false,
+          "description": "Automatically find modules used in current file, and load them to language server. need verible-verilog-syntax be set correctly and enable symlinks",
+          "type": "boolean"
+        },
         "verilog.inlayHints.wildcardPorts": {
           "default": "on",
           "description": "Show wildcard port hints (.*: port1, port2, etc.) in module instantiation",

--- a/package.json
+++ b/package.json
@@ -307,6 +307,14 @@
           "description": "Whether to index all .svh files",
           "type": "boolean"
         },
+        "verilog.index.extraSymlinkSource": {
+          "default": [],
+          "description": "Add extra source file directories for symlink",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "verilog.ctags.path": {
           "description": "Path to ctags universal executable",
           "default": "",

--- a/src/IndexComponent.ts
+++ b/src/IndexComponent.ts
@@ -22,6 +22,11 @@ export class IndexComponent extends ExtensionComponent {
     description: 'Whether to index all .svh files',
   })
 
+  extraSymlinkSource: ConfigObject<string[]> = new ConfigObject({
+    default: [],
+    description: 'Add extra source file directories for symlink',
+  })
+
   // <workspace-specific-dir>/.sv_cache/files
   cacheDir: vscode.Uri | undefined
 
@@ -121,6 +126,9 @@ export class IndexComponent extends ExtensionComponent {
     }
 
     let files: vscode.Uri[] = await ext.findModules()
+
+    let promises = this.extraSymlinkSource.getValue().map((dir)=>ext.findModules(dir))
+    files = files.concat((await Promise.all(promises)).flat())
     this.logger.info('indexing ' + files.length + ' files')
 
     await vscode.window.withProgress(

--- a/src/LSComponent.ts
+++ b/src/LSComponent.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node'
 import { CommandNode, ConfigObject, ExtensionComponent } from './lib/libconfig'
 import { anyVerilogSelector, systemverilogSelector } from './utils'
+import { activateAutoLoad, deactivateAutoLoad } from './autoloader'
 
 export enum LanguageServers {
   Ctags = 'ctags',
@@ -51,6 +52,16 @@ export class LanguageServerComponent extends ExtensionComponent {
     description: 'Arguments to pass to the server when debugging',
   })
 
+  pathToVeribleSyntax: ConfigObject<string> = new ConfigObject({
+    default: "verible-verilog-syntax",
+    description: 'Path to the verible-verilog-syntax tool',
+  })
+
+  autoLoadModules: ConfigObject<boolean> = new ConfigObject<boolean>({
+    default: false,
+    description: "Automatically find modules used in current file, and load them to language server. need verible-verilog-syntax be set correctly and enable symlinks"
+  })
+
   restartLanguageServer: CommandNode = new CommandNode(
     {
       title: 'Restart Language Server',
@@ -85,6 +96,7 @@ export class LanguageServerComponent extends ExtensionComponent {
   }
 
   async stop() {
+    deactivateAutoLoad()
     if (this.client !== undefined) {
       await this.client.stop()
       this.client = undefined
@@ -105,6 +117,9 @@ export class LanguageServerComponent extends ExtensionComponent {
 
     this.client = new LanguageClient(selection, selection, serverOptions, clientOptions)
     await this.client.start()
+    if(this.autoLoadModules.getValue()) {
+      activateAutoLoad(this.logger)
+    }
     this.logger.info(`${selection} language server started`)
   }
 }

--- a/src/autoloader.ts
+++ b/src/autoloader.ts
@@ -1,0 +1,158 @@
+import * as vscode from "vscode";
+import * as fs from "fs";
+import { ext } from "./extension";
+import path from "path";
+import { Logger } from "./lib/logger";
+import { spawn } from "child_process";
+
+
+function runVerible(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      ext.languageServer.pathToVeribleSyntax.getValue(),
+      [
+        "--export_json",
+        "--printtree",
+        filePath,
+      ], {
+      stdio: ["ignore", "pipe", "ignore"],
+      shell: false
+    });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve(stdout);
+    });
+  });
+}
+
+
+// using verible-verilog-syntax
+async function getUsedModules(filePath: string,logger:Logger) {
+  const jsonStr = await runVerible(filePath)
+  const ast = JSON.parse(jsonStr);
+  const treeAst = ast[Object.keys(ast)[0]].tree
+
+  function findSubmodules(node: any, parentChain: any[] = []): Set<string> {
+    let result = new Set<string>();
+    const chain = [...parentChain, node];
+    if (node.tag === "SymbolIdentifier" && chain.length >= 5) {
+      const fourthParent = chain[chain.length - 5];
+      if (fourthParent?.tag === "kInstantiationType") {
+        const file = node.text;
+        if(file){
+          result.add(file);
+        }
+      }
+    }
+
+    for (const child of node.children || []) {
+      if(child){
+        const modules = findSubmodules(child, chain)
+        for(const module of modules) {
+          result.add(module);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  return findSubmodules(treeAst)
+}
+
+
+async function findFileInDir(
+  dir: string,
+  targetName: string,
+  suffixies: string[],
+  logger:Logger
+): Promise<string | undefined> {
+  const targetLower = targetName.toLowerCase();
+
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isFile() && !entry.isSymbolicLink()) {
+      continue
+    }
+    const ext = path.extname(entry.name).toLowerCase();
+    const base = path.basename(entry.name, ext).toLowerCase();
+
+    if (base === targetLower && suffixies.includes(ext)) {
+      return path.join(dir, entry.name);
+    }
+  }
+
+  return undefined;
+}
+
+
+
+async function getFileFromModuleName(file: string,suffix:string[],logger:Logger):Promise<string | undefined>{
+  const dirPath = ext.index.cacheDir
+  if(!dirPath) return undefined
+  const fileOrLinkPath = await findFileInDir(dirPath.fsPath,file,suffix,logger)
+  if(!fileOrLinkPath) return undefined
+  const stats = await fs.promises.lstat(fileOrLinkPath);
+
+  if (stats.isSymbolicLink()) {
+    const realPath = await fs.promises.readlink(fileOrLinkPath);
+    return path.resolve(path.dirname(fileOrLinkPath), realPath);
+  } else {
+    return fileOrLinkPath;
+  }
+}
+
+async function preloadModulesInFile(
+  filePath: string,
+  logger:Logger
+) {
+  const suffixs = [".svh",".sv",".v"]
+  const fileUri = vscode.Uri.file(filePath);
+  const ext = path.extname(fileUri.fsPath).toLowerCase();
+  if(!suffixs.includes(ext)) return;
+
+  logger.info(`preloading file ${filePath}`)
+  if (!fs.existsSync(filePath)) {
+    logger.warn(`unable to preload file ${filePath}`)
+    return;
+  }
+
+  async function preloadModule(module:string){
+    const file = await getFileFromModuleName(module,suffixs,logger);
+    if(file !== undefined) {
+      vscode.workspace.openTextDocument(file)
+    } else {
+      logger.warn(`not found file for module ${module}`)
+    }
+  }
+
+  const usedModules = await getUsedModules(filePath,logger)
+  for(const module of usedModules) {
+    preloadModule(module)
+  }
+}
+
+var listener: vscode.Disposable|undefined = undefined
+
+export function activateAutoLoad(logger:Logger) {
+  deactivateAutoLoad()
+  vscode.window.visibleTextEditors.forEach((editor) => {
+    preloadModulesInFile(editor.document.fileName,logger)
+  })
+  listener = vscode.window.onDidChangeVisibleTextEditors((editors) => {
+    for(const editor of editors) {
+      preloadModulesInFile(editor.document.fileName,logger)
+    }
+  });
+}
+
+export function deactivateAutoLoad(){
+  if(listener) {
+    listener.dispose()
+    listener = undefined
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -338,9 +338,8 @@ export class VerilogExtension extends ActivityBarComponent {
     return this.languageServer.server.getValue() === LanguageServers.Slang
   }
 
-  public async findFiles(globs: string[]): Promise<vscode.Uri[]> {
-    let ws = getWorkspaceFolder()
-    if (ws === undefined) {
+  public async findFiles(globs: string[],folder:string | undefined = getWorkspaceFolder()): Promise<vscode.Uri[]> {
+    if(folder === undefined) {
       return []
     }
     const exclude: string = this.excludeGlob.getValue()
@@ -350,7 +349,7 @@ export class VerilogExtension extends ActivityBarComponent {
       if (path.isAbsolute(str)) {
         ret = (await asyncGlob(str)).map((p) => vscode.Uri.file(p))
       } else {
-        ret = await vscode.workspace.findFiles(new vscode.RelativePattern(ws, str), exclude)
+        ret = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, str), exclude)
       }
       return ret
     }
@@ -369,8 +368,8 @@ export class VerilogExtension extends ActivityBarComponent {
     return await this.findFiles(incGlobs)
   }
 
-  public async findModules(): Promise<vscode.Uri[]> {
-    return await this.findFiles(this.moduleGlobs.getValue())
+  public async findModules(folder:string | undefined = getWorkspaceFolder()): Promise<vscode.Uri[]> {
+    return await this.findFiles(this.moduleGlobs.getValue(),folder)
   }
 }
 


### PR DESCRIPTION
i am using verible-verilog-ls to view some vivado projects. but it's Go-To-Definition cannot find modules in other file(unless once opened in workspace). so i made some changes to solve it. all of the changes are controlled by configs.

i use verible-verilog-syntax to find modules referred in current file, find symlink files and then load them by vscode.workspace.openTextDocument(). then verible can recognize these modules.

besides, now it's able to add external directories for symlinks. i can add some libraries provided by vivado (outside the workspace).  linter and language server can recognize the modules such as BUFG, BUFDS by symlinks, and even jump to them by Go-To-Definition.

if i load all the modules at once, it will cost a long time. so i only tried to load the visible modules. all of the changes are controlled by configs.